### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw (angular-di-provide.md)

### DIFF
--- a/source/_posts/2017-03-11-angular-di-provide.md
+++ b/source/_posts/2017-03-11-angular-di-provide.md
@@ -61,4 +61,4 @@ export class BeverageService {
 ```
 
 ## DI學習參考
-[oomusou的文章，深入探討 Angular 的 DI 與 Provider](http://oomusou.io/angular/angular-di/)
+[oomusou的文章，深入探討 Angular 的 DI 與 Provider](https://old-oomusou.goodjack.tw/angular/di/)


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw